### PR TITLE
Remove more Bazel-specific content from generated Xcode project when targeting xcodebuild

### DIFF
--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -502,17 +502,19 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
 
         target_settings = {
             "PRODUCT_NAME": target_name,
-            "BAZEL_BIN_SUBDIR": target_info.bazel_bin_subdir,
             "MACH_O_TYPE": target_macho_type,
             "CLANG_ENABLE_MODULES": "YES",
             "CLANG_ENABLE_OBJC_ARC": "YES",
-            "BAZEL_BUILD_TARGET_LABEL": target_info.bazel_build_target_name,
-            "BAZEL_BUILD_TARGET_WORKSPACE": target_info.bazel_build_target_workspace,
         }
-
-        target_settings["BAZEL_SWIFTMODULEFILES_TO_COPY"] = _swiftmodulepaths_for_target(target_name, all_transitive_targets)
-        target_settings["HEADER_SEARCH_PATHS"] = _header_search_paths_for_target(target_name, all_transitive_targets)
-        target_settings["FRAMEWORK_SEARCH_PATHS"] = _framework_search_paths_for_target(target_name, all_transitive_targets)
+        if ctx.attr.target_build_system == _BAZEL:
+            target_settings.update({
+                "BAZEL_BIN_SUBDIR": target_info.bazel_bin_subdir,
+                "BAZEL_BUILD_TARGET_LABEL": target_info.bazel_build_target_name,
+                "BAZEL_BUILD_TARGET_WORKSPACE": target_info.bazel_build_target_workspace,
+                "BAZEL_SWIFTMODULEFILES_TO_COPY": _swiftmodulepaths_for_target(target_name, all_transitive_targets),
+                "HEADER_SEARCH_PATHS": _header_search_paths_for_target(target_name, all_transitive_targets),
+                "FRAMEWORK_SEARCH_PATHS": _framework_search_paths_for_target(target_name, all_transitive_targets),
+            })
 
         macros = ["\"%s\"" % d for d in target_info.cc_defines.to_list()]
         macros.append("$(inherited)")
@@ -529,13 +531,15 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
         target_settings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = " ".join(
             ["\"%s\"" % d for d in defines_without_equal_sign],
         )
-        target_settings["BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS"] = " ".join(
-            ["-D%s" % d for d in target_info.cc_defines.to_list()],
-        )
+        if ctx.attr.target_build_system == _BAZEL:
+            target_settings["BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS"] = " ".join(
+                ["-D%s" % d for d in target_info.cc_defines.to_list()],
+            )
 
         if product_type == "application":
-            target_settings["INFOPLIST_FILE"] = "$BAZEL_STUBS_DIR/Info-stub.plist"
             target_settings["PRODUCT_BUNDLE_IDENTIFIER"] = target_info.bundle_id
+            if ctx.attr.target_build_system == _BAZEL:
+                target_settings["INFOPLIST_FILE"] = "$BAZEL_STUBS_DIR/Info-stub.plist"
 
         if product_type == "bundle.unit-test":
             target_settings["SUPPORTS_MACCATALYST"] = False
@@ -547,6 +551,11 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
 
         target_settings["VALID_ARCHS"] = _ARCH_MAPPING[target_info.platform_type]
 
+        pre_build_scripts = [] if ctx.attr.target_build_system == _XCODEBUILD else [{
+            "name": "Build with bazel",
+            "script": _BUILD_WITH_BAZEL_SCRIPT,
+        }]
+
         xcodeproj_targets_by_name[target_name] = {
             "sources": compiled_sources + compiled_non_arc_sources + asset_sources,
             "type": product_type,
@@ -554,10 +563,7 @@ def _populate_xcodeproj_targets_and_schemes(ctx, targets, src_dot_dots, all_tran
             "deploymentTarget": target_info.minimum_os_version,
             "settings": target_settings,
             "dependencies": target_dependencies,
-            "preBuildScripts": [{
-                "name": "Build with bazel",
-                "script": _BUILD_WITH_BAZEL_SCRIPT,
-            }],
+            "preBuildScripts": pre_build_scripts,
         }
 
         # Skip a scheme generation if allowlist is not empty

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -23,6 +23,10 @@ _ARCH_MAPPING = {
     "macos": "i386 x86_64",
 }
 
+# Target build systems
+_BAZEL = "bazel"
+_XCODEBUILD = "xcodebuild"
+
 _PRODUCT_SPECIFIER_LENGTH = len("com.apple.product-type.")
 
 _IGNORE_AS_TARGET_TAG = "xcodeproj-ignore-as-target"
@@ -680,8 +684,7 @@ def _xcodeproj_impl(ctx):
         "settingPresets": "none",
     }
 
-    build_with_xcodebuild = ctx.attr.build_with_xcodebuild
-    proj_settings = _xcodebuild_proj_settings() if build_with_xcodebuild else _bazel_proj_settings(ctx, script_dot_dots)
+    proj_settings = _xcodebuild_proj_settings() if ctx.attr.target_build_system == _XCODEBUILD else _bazel_proj_settings(ctx, script_dot_dots)
 
     targets = []
     all_transitive_targets = depset(transitive = _get_attr_values_for_name(ctx.attr.deps, _TargetInfo, "targets")).to_list()
@@ -802,7 +805,7 @@ Product types must be valid apple product types, e.g. application, bundle.unit-t
 For a full list, see under keys of `PRODUCT_TYPE_UTI` under
 https://www.rubydoc.info/github/CocoaPods/Xcodeproj/Xcodeproj/Constants
 """),
-        "build_with_xcodebuild": attr.bool(default = False, mandatory = False, doc = "The generated Xcode project will build with xcodebuild instead of Bazel."),
+        "target_build_system": attr.string(default = "bazel", doc = "The build system that the generated project should use: 'bazel' (the default) or 'xcodebuild' (experimental)", mandatory = False, values = [_BAZEL, _XCODEBUILD]),
         "_xcodeproj_installer_template": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:xcodeproj-installer.sh"), allow_single_file = ["sh"]),
         "_infoplist_stub": attr.label(executable = False, default = Label("//rules/test_host_app:Info.plist"), allow_single_file = ["plist"]),
         "_workspace_xcsettings": attr.label(executable = False, default = Label("//tools/xcodeproj_shims:WorkspaceSettings.xcsettings"), allow_single_file = ["xcsettings"]),

--- a/rules/xcodeproj.bzl
+++ b/rules/xcodeproj.bzl
@@ -757,6 +757,7 @@ def _xcodeproj_impl(ctx):
             "$(output_processor_path)": ctx.file.output_processor.short_path,
             "$(workspacesettings_xcsettings_short_path)": ctx.file._workspace_xcsettings.short_path,
             "$(ideworkspacechecks_plist_short_path)": ctx.file._workspace_checks.short_path,
+            "$(target_build_system)": ctx.attr.target_build_system,
         },
         is_executable = True,
     )

--- a/tests/ios/xcodeproj/BUILD.bazel
+++ b/tests/ios/xcodeproj/BUILD.bazel
@@ -20,12 +20,12 @@ xcodeproj(
     name = "Xcodebuild-Single-Static-Framework-Project",
     testonly = True,
     bazel_path = "bazelisk",
-    build_with_xcodebuild = True,
     generate_schemes_for_product_types = [
         "framework.static",
         "bundle.unit-test",
     ],
     include_transitive_targets = True,
+    target_build_system = "xcodebuild",
     deps = [
         "//tests/ios/frameworks/objc:ObjcFramework",
         "//tests/ios/frameworks/objc:ObjcFrameworkTests",

--- a/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Xcodebuild-Single-Static-Framework-Project.xcodeproj/project.pbxproj
@@ -130,7 +130,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5788F7782380D3838C83887A /* Build configuration list for PBXNativeTarget "ObjcFrameworkTestLib" */;
 			buildPhases = (
-				33E375BE73B9CD01B0D5F4EB /* Build with bazel */,
 				B3E01DFF8F12CF408B966843 /* Sources */,
 			);
 			buildRules = (
@@ -146,7 +145,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 012F347C2B10EDCAE740230C /* Build configuration list for PBXNativeTarget "ObjcFrameworkTests" */;
 			buildPhases = (
-				6522B6F4E0F35BA0870F2706 /* Build with bazel */,
 				8B44A9E97D6D38A238644965 /* Sources */,
 			);
 			buildRules = (
@@ -162,7 +160,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BCC9A55DDED404AD1056D098 /* Build configuration list for PBXNativeTarget "ObjcFramework" */;
 			buildPhases = (
-				664FCBDF2AE075BD785BDDAD /* Build with bazel */,
 				420D44581C2B4A6652F8C264 /* Sources */,
 			);
 			buildRules = (
@@ -202,63 +199,6 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		33E375BE73B9CD01B0D5F4EB /* Build with bazel */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Build with bazel";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
-		};
-		6522B6F4E0F35BA0870F2706 /* Build with bazel */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Build with bazel";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
-		};
-		664FCBDF2AE075BD785BDDAD /* Build with bazel */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Build with bazel";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\nset -euxo pipefail\ncd $BAZEL_WORKSPACE_ROOT\n\nexport BAZEL_DIAGNOSTICS_DIR=\"$BUILD_DIR/../../bazel-xcode-diagnostics/\"\nmkdir -p $BAZEL_DIAGNOSTICS_DIR\nexport DATE_SUFFIX=\"$(date +%Y%m%d.%H%M%S%L)\"\nexport BAZEL_BUILD_EVENT_TEXT_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-event-$DATE_SUFFIX.txt\"\nexport BAZEL_BUILD_EXECUTION_LOG_FILENAME=\"$BAZEL_DIAGNOSTICS_DIR/build-execution-log-$DATE_SUFFIX.log\"\nenv -u RUBYOPT -u RUBY_HOME -u GEM_HOME $BAZEL_BUILD_EXEC $BAZEL_BUILD_TARGET_LABEL\n$BAZEL_INSTALLER\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		420D44581C2B4A6652F8C264 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -290,16 +230,9 @@
 		66031105B886CCF95271CCFB /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
-				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFramework";
-				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -320,16 +253,9 @@
 		7A33049F374A7CA38EF5B5B2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
-				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTestLib";
-				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;
@@ -341,16 +267,9 @@
 		7B372BD4970D695DBB06AE33 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
-				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTests";
-				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTests;
@@ -363,16 +282,9 @@
 		9F43131F1F2552DD64205507 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
-				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTestLib";
-				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTestLib;
@@ -395,16 +307,9 @@
 		F5917DE04F056215EE0B9206 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
-				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFramework";
-				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7bf874b56ea0/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework_private_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFramework;
@@ -416,16 +321,9 @@
 		FAB129E691E21AF69143C570 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_BIN_SUBDIR = /tests/ios/frameworks/objc;
-				BAZEL_BUILD_TARGET_LABEL = "tests/ios/frameworks/objc:ObjcFrameworkTests";
-				BAZEL_BUILD_TARGET_WORKSPACE = build_bazel_rules_ios;
-				BAZEL_LLDB_SWIFT_EXTRA_CLANG_FLAGS = "";
-				BAZEL_SWIFTMODULEFILES_TO_COPY = "";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-36e46a5aeba1/bin/tests/ios/frameworks/objc/ObjcFramework\" \"$BAZEL_WORKSPACE_ROOT/bazel-out/applebin_ios-ios_x86_64-dbg-ST-ad27ed8b0869/bin/tests/ios/frameworks/objc/ObjcFrameworkTestLib\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MACH_O_TYPE = "$(inherited)";
 				PRODUCT_NAME = ObjcFrameworkTests;

--- a/tools/xcodeproj_shims/xcodeproj-installer.sh
+++ b/tools/xcodeproj_shims/xcodeproj-installer.sh
@@ -6,49 +6,49 @@ readonly project_path="${PWD}/$(project_short_path)"
 readonly dest="${BUILD_WORKSPACE_DIRECTORY}/$(project_short_path)/"
 readonly tmp_dest=$(mktemp -d)/$(project_full_path)/
 
-readonly installer="$(installer_short_path)"
-
 rm -fr "${tmp_dest}"
 mkdir -p "$(dirname $tmp_dest)"
 cp -r "${project_path}" "$tmp_dest"
 chmod -R +w "${tmp_dest}"
 
-readonly stubs_dir="${tmp_dest}/bazelstubs"
-mkdir -p "${stubs_dir}"
+if [ "$(target_build_system)" = "bazel" ]; then
+    readonly stubs_dir="${tmp_dest}/bazelstubs"
+    mkdir -p "${stubs_dir}"
 
-readonly installers_dir="${tmp_dest}/bazelinstallers"
-mkdir -p "${installers_dir}"
+    readonly installers_dir="${tmp_dest}/bazelinstallers"
+    mkdir -p "${installers_dir}"
 
-readonly print_json_installers_dir="${stubs_dir}/print_json_leaf_nodes.runfiles/"
-mkdir -p "${print_json_installers_dir}"
+    readonly print_json_installers_dir="${stubs_dir}/print_json_leaf_nodes.runfiles/"
+    mkdir -p "${print_json_installers_dir}"
 
-for PRINT_INSTALLER_PATH in $(print_json_leaf_nodes_runfiles)
-do
-  mkdir -p "${print_json_installers_dir}/$(dirname $PRINT_INSTALLER_PATH)"
-  cp "${PWD}/../$PRINT_INSTALLER_PATH" "${print_json_installers_dir}/$PRINT_INSTALLER_PATH"
-done
+    for PRINT_INSTALLER_PATH in $(print_json_leaf_nodes_runfiles)
+    do
+      mkdir -p "${print_json_installers_dir}/$(dirname $PRINT_INSTALLER_PATH)"
+      cp "${PWD}/../$PRINT_INSTALLER_PATH" "${print_json_installers_dir}/$PRINT_INSTALLER_PATH"
+    done
 
-for INSTALLER_PATH in $(installer_runfile_short_paths)
-do
-  cp "$INSTALLER_PATH" "${installers_dir}/"
-done
-cp "$(installer_short_path)" "${installers_dir}/"
+    for INSTALLER_PATH in $(installer_runfile_short_paths)
+    do
+      cp "$INSTALLER_PATH" "${installers_dir}/"
+    done
+    cp "$(installer_short_path)" "${installers_dir}/"
 
-cp "$(clang_stub_short_path)" "${stubs_dir}/clang-stub"
-cp "$(clang_stub_ld_path)" "${stubs_dir}/ld-stub"
-cp "$(clang_stub_swiftc_path)" "${stubs_dir}/swiftc-stub"
-cp "$(index_import_short_path)" "${installers_dir}/index-import"
-cp "$(print_json_leaf_nodes_path)" "${stubs_dir}/print_json_leaf_nodes"
-cp "$(infoplist_stub)" "${stubs_dir}/Info-stub.plist"
-cp "$(build_wrapper_path)" "${stubs_dir}/build-wrapper"
-cp "$(output_processor_path)" "${stubs_dir}/output-processor.rb"
+    cp "$(clang_stub_short_path)" "${stubs_dir}/clang-stub"
+    cp "$(clang_stub_ld_path)" "${stubs_dir}/ld-stub"
+    cp "$(clang_stub_swiftc_path)" "${stubs_dir}/swiftc-stub"
+    cp "$(index_import_short_path)" "${installers_dir}/index-import"
+    cp "$(print_json_leaf_nodes_path)" "${stubs_dir}/print_json_leaf_nodes"
+    cp "$(infoplist_stub)" "${stubs_dir}/Info-stub.plist"
+    cp "$(build_wrapper_path)" "${stubs_dir}/build-wrapper"
+    cp "$(output_processor_path)" "${stubs_dir}/output-processor.rb"
 
-# The new build system leaves a subdirectory called XCBuildData in the DerivedData directory which causes incremental build and test attempts to fail at launch time.
-# The error message says "Cannot attach to pid." This error seems to happen in the Xcode IDE, not when the project is tested from the xcodebuild command.
-# Therefore, we force xcode to use the legacy build system by adding the contents of WorkspaceSettings.xcsettings to the generated project.
-mkdir -p "$tmp_dest/project.xcworkspace/xcshareddata/"
-cp "$(workspacesettings_xcsettings_short_path)" "$tmp_dest/project.xcworkspace/xcshareddata/"
-cp "$(ideworkspacechecks_plist_short_path)" "$tmp_dest/project.xcworkspace/xcshareddata/"
+    # The new build system leaves a subdirectory called XCBuildData in the DerivedData directory which causes incremental build and test attempts to fail at launch time.
+    # The error message says "Cannot attach to pid." This error seems to happen in the Xcode IDE, not when the project is tested from the xcodebuild command.
+    # Therefore, we force xcode to use the legacy build system by adding the contents of WorkspaceSettings.xcsettings to the generated project.
+    mkdir -p "$tmp_dest/project.xcworkspace/xcshareddata/"
+    cp "$(workspacesettings_xcsettings_short_path)" "$tmp_dest/project.xcworkspace/xcshareddata/"
+    cp "$(ideworkspacechecks_plist_short_path)" "$tmp_dest/project.xcworkspace/xcshareddata/"
+fi
 
 chmod -R +w "${tmp_dest}"
 


### PR DESCRIPTION
Gets us closer to a working `xcodeproj` rule that generates an Xcode project file that builds with `xcodebuild`.