### PR TITLE
Fix dsym installer script

### DIFF
--- a/tools/xcodeproj_shims/installers/dsyms.sh
+++ b/tools/xcodeproj_shims/installers/dsyms.sh
@@ -16,7 +16,7 @@ if [[ -z $dsym_input ]]; then
   exit 0
 fi
 
-echo "Found ${#dsym_input[@]} DSYMS"
+echo "Found $dsym_input"
 
 rsync \
   --recursive --chmod=u+w --delete -i \


### PR DESCRIPTION
This script as failing to copy any dsyms and exiting out with an error: 

```
Users/ahmed/Developer/slack-objc/project-gen/SlackBazel.xcodeproj/bazelinstallers/dsyms.sh: line 19: dsym_input: unbound variable```
